### PR TITLE
lexer+parser: Convert Nexter signatures to 'Next() ($VALUE, error)

### DIFF
--- a/lexer/README.md
+++ b/lexer/README.md
@@ -380,7 +380,7 @@ func main() {
 
 	// Process lexer-emitted tokens
 	//
-	for t, err := tokens.Next(); err == nil; t, err = tokens.Next() { // We only emit EOF so !nil should do it
+	for t, lexErr := tokens.Next(); lexErr == nil; t, lexErr = tokens.Next() { // We only emit EOF so !nil should do it
 		chars += len(t.Value())
 
 		switch t.Type() {

--- a/lexer/README.md
+++ b/lexer/README.md
@@ -298,21 +298,15 @@ const (
 
 #### Retrieving Emitted Tokens ( `token.Nexter` )
 
-When called, the Lex* functions will return a `token.Nexter` which provides methods to retrieve tokens emitted from the lexer.
-
-`token.Nexter` implements a basic iterator pattern:
+When called, the Lex* functions will return a `token.Nexter` which provides a means of retrieving tokens (and errors) emitted from the lexer.
 
 ```go
 type Nexter interface {
 
-	// HasNext confirms if there are tokens available.
-	// If it returns true, you can safely call Next() to retrieve the next token.
+	// Next tries to fetch the next available token, returning an error if something goes wrong.
+	// Will return io.EOF to indicate end-of-file.
 	//
-	HasNext() bool
-
-	// Next Retrieves the next token from the lexer.
-	//
-	Next() lexer.Token
+	Next() (Token, error)
 }
 ```
 
@@ -386,8 +380,7 @@ func main() {
 
 	// Process lexer-emitted tokens
 	//
-	for tokens.HasNext() {
-		t := tokens.Next()
+	for t, err := tokens.Next(); err == nil; t, err = tokens.Next() { // We only emit EOF so !nil should do it
 		chars += len(t.Value())
 
 		switch t.Type() {

--- a/lexer/README.md
+++ b/lexer/README.md
@@ -298,7 +298,7 @@ const (
 
 #### Retrieving Emitted Tokens ( `token.Nexter` )
 
-When called, the Lex* functions will return a `token.Nexter` which provides a means of retrieving tokens (and errors) emitted from the lexer.
+When called, the Lex* functions will return a `token.Nexter` which provides a means of retrieving tokens (and errors) emitted from the lexer:
 
 ```go
 type Nexter interface {

--- a/lexer/doc.go
+++ b/lexer/doc.go
@@ -180,7 +180,7 @@ You define your own token types starting from T_START:
 
 Retrieving Emitted Tokens
 
-When called, the `Lex*` functions will return a `token.Nexter` which provides means of retrieving tokens (and errors)
+When called, the `Lex*` functions will return a `token.Nexter` which provides a means of retrieving tokens (and errors)
 emitted from the lexer:
 
 	type Nexter interface {

--- a/lexer/doc.go
+++ b/lexer/doc.go
@@ -180,20 +180,15 @@ You define your own token types starting from T_START:
 
 Retrieving Emitted Tokens
 
-When called, the `Lex*` functions will return a `token.Nexter` which provides methods to retrieve tokens emitted from the
-lexer.
-
-`token.Nexter` implements a basic iterator pattern:
+When called, the `Lex*` functions will return a `token.Nexter` which provides means of retrieving tokens (and errors)
+emitted from the lexer:
 
 	type Nexter interface {
 
-		// HasNext confirms if there are tokens available.
+		// Next tries to fetch the next available token, returning an error if something goes wrong.
+		// Will return io.EOF to indicate end-of-file.
 		//
-		HasNext() bool
-
-		// Next Retrieves the next token from the lexer.
-		//
-		Next() token.Token
+		Next() (token.Token, error)
 	}
 
 

--- a/lexer/examples/wordcount/wordcount.go
+++ b/lexer/examples/wordcount/wordcount.go
@@ -61,8 +61,7 @@ func main() {
 
 	// Process lexer-emitted tokens
 	//
-	for tokens.HasNext() {
-		t := tokens.Next()
+	for t, err := tokens.Next(); err == nil; t, err = tokens.Next() { // We only emit EOF so !nil should do it
 		chars += len(t.Value())
 
 		switch t.Type() {

--- a/lexer/examples/wordcount/wordcount.go
+++ b/lexer/examples/wordcount/wordcount.go
@@ -61,7 +61,7 @@ func main() {
 
 	// Process lexer-emitted tokens
 	//
-	for t, err := tokens.Next(); err == nil; t, err = tokens.Next() { // We only emit EOF so !nil should do it
+	for t, lexErr := tokens.Next(); lexErr == nil; t, lexErr = tokens.Next() { // We only emit EOF so !nil should do it
 		chars += len(t.Value())
 
 		switch t.Type() {

--- a/lexer/go.mod
+++ b/lexer/go.mod
@@ -10,4 +10,4 @@ require github.com/tekwizely/go-parsing/lexer/token v0.0.0-20190621000622-442f34
 
 // For Local testing against changes that aren't upstream
 //
-//replace github.com/tekwizely/go-parsing/lexer/token => ./token
+replace github.com/tekwizely/go-parsing/lexer/token => ./token

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -127,7 +127,7 @@ func expectMatchEmitString(t *testing.T, l *Lexer, match string, emitType token.
 //
 func TestNilFn(t *testing.T) {
 	nexter := LexString("", nil)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestLexerFnSkippedWhenNoHasNext
@@ -138,7 +138,7 @@ func TestLexerFnSkippedWhenNoHasNext(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmittoken.Ttype
@@ -149,9 +149,8 @@ func TestEmitEmptyType(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, true)
 	expectNexterNext(t, nexter, T_START, "")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitEmptyToken
@@ -162,9 +161,8 @@ func TestEmitEmptyToken(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, true)
 	expectNexterNext(t, nexter, T_START, "")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestCanPeek
@@ -186,7 +184,7 @@ func TestCanPeek(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestCanPeekPastEOF
@@ -210,7 +208,7 @@ func TestCanPeekPastEOF(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestCanPeekRangeError
@@ -226,7 +224,7 @@ func TestCanPeekRangeError(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestPeek1
@@ -237,7 +235,7 @@ func TestPeek1(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("1", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 
 }
 
@@ -250,7 +248,7 @@ func TestPeek11(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("AB", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestPeek12
@@ -262,7 +260,7 @@ func TestPeek12(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("AB", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestPeekEmpty
@@ -276,7 +274,7 @@ func TestPeekEmpty(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestPeekRangeError
@@ -292,7 +290,7 @@ func TestPeekRangeError(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestHasNextTrue
@@ -303,7 +301,7 @@ func TestHasNextTrue(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("1", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 
 }
 
@@ -317,7 +315,7 @@ func TestHasNextFalse(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 
 }
 
@@ -330,7 +328,7 @@ func TestNext1(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("AB", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestNext2
@@ -344,7 +342,7 @@ func TestNext2(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("AB", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestNextEmpty
@@ -358,7 +356,7 @@ func TestNextEmpty(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestNextEmit1
@@ -372,7 +370,7 @@ func TestNextEmit1(t *testing.T) {
 	}
 	nexter := LexString("AB", fn)
 	expectNexterNext(t, nexter, T_CHAR, "A")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestNextEmit2
@@ -390,7 +388,7 @@ func TestNextEmit2(t *testing.T) {
 	nexter := LexString("AB", fn)
 	expectNexterNext(t, nexter, T_CHAR, "A")
 	expectNexterNext(t, nexter, T_CHAR, "B")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMatchInt
@@ -402,7 +400,7 @@ func TestMatchInt(t *testing.T) {
 	}
 	nexter := LexString("123", fn)
 	expectNexterNext(t, nexter, T_INT, "123")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMatchIntString
@@ -416,7 +414,7 @@ func TestMatchIntString(t *testing.T) {
 	nexter := LexString("123ABC", fn)
 	expectNexterNext(t, nexter, T_INT, "123")
 	expectNexterNext(t, nexter, T_STRING, "ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMatchString
@@ -428,7 +426,7 @@ func TestMatchString(t *testing.T) {
 	}
 	nexter := LexString("123ABC", fn)
 	expectNexterNext(t, nexter, T_STRING, "123ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMatchRunes
@@ -440,7 +438,7 @@ func TestMatchRunes(t *testing.T) {
 	}
 	nexter := LexRunes([]rune("123ABC"), fn)
 	expectNexterNext(t, nexter, T_STRING, "123ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMatchBytes
@@ -452,7 +450,7 @@ func TestMatchBytes(t *testing.T) {
 	}
 	nexter := LexBytes([]byte("123ABC"), fn)
 	expectNexterNext(t, nexter, T_STRING, "123ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMatchReader
@@ -464,7 +462,7 @@ func TestMatchReader(t *testing.T) {
 	}
 	nexter := LexReader(strings.NewReader("123ABC"), fn)
 	expectNexterNext(t, nexter, T_STRING, "123ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestDiscardToken1
@@ -476,7 +474,7 @@ func TestDiscardToken1(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123ABC", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestDiscardToken2
@@ -490,7 +488,7 @@ func TestDiscardToken2(t *testing.T) {
 	}
 	nexter := LexString("123ABC", fn)
 	expectNexterNext(t, nexter, T_INT, "123")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestDiscardToken3
@@ -504,7 +502,7 @@ func TestDiscardToken3(t *testing.T) {
 	}
 	nexter := LexString("123ABC", fn)
 	expectNexterNext(t, nexter, T_STRING, "ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitEOF1
@@ -516,7 +514,7 @@ func TestEmitEOF1(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitEOF2
@@ -529,7 +527,7 @@ func TestEmitEOF2(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitEOF3
@@ -541,7 +539,7 @@ func TestEmitEOF3(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitEOF4
@@ -553,7 +551,7 @@ func TestEmitEOF4(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitEOF5
@@ -566,7 +564,7 @@ func TestEmitEOF5(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitError
@@ -577,8 +575,8 @@ func TestEmitError(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterNext(t, nexter, T_LEX_ERR, "ERROR")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterError(t, nexter, "ERROR")
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitErrorf
@@ -589,8 +587,8 @@ func TestEmitErrorf(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterNext(t, nexter, T_LEX_ERR, "ERROR: Error 1")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterError(t, nexter, "ERROR: Error 1")
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitAfterEOF
@@ -604,7 +602,7 @@ func TestEmitAfterEOF(t *testing.T) {
 		return nil
 	}
 	assertPanic(t, func() {
-		LexString("123", fn).Next()
+		_, _ = LexString("123", fn).Next()
 	}, "Lexer.EmitToken: No further emits allowed after EOF is emitted")
 }
 
@@ -618,7 +616,7 @@ func TestEmitTypeAfterEOF(t *testing.T) {
 		return nil
 	}
 	assertPanic(t, func() {
-		LexString("123", fn).Next()
+		_, _ = LexString("123", fn).Next()
 	}, "Lexer.EmitType: No further emits allowed after EOF is emitted")
 }
 
@@ -632,7 +630,7 @@ func TestCanPeekAfterEOF(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestPeekAfterEOF
@@ -647,7 +645,7 @@ func TestPeekAfterEOF(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestHasNextAfterEOF
@@ -660,7 +658,7 @@ func TestHasNextAfterEOF(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestNextAfterEOF
@@ -675,7 +673,7 @@ func TestNextAfterEOF(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestPeekTokenAfterEOF
@@ -691,7 +689,7 @@ func TestPeekTokenAfterEOF(t *testing.T) {
 		return nil
 	}
 	nexter := LexString("123", fn)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestEmitErrorAfterEOF
@@ -704,7 +702,7 @@ func TestEmitErrorAfterEOF(t *testing.T) {
 		return nil
 	}
 	assertPanic(t, func() {
-		LexString("123", fn).Next()
+		_, _ = LexString("123", fn).Next()
 	}, "Lexer.EmitError: No further emits allowed after EOF is emitted")
 }
 
@@ -719,6 +717,6 @@ func TestDiscardAfterEOF(t *testing.T) {
 		return nil
 	}
 	assertPanic(t, func() {
-		LexString("123", fn).Next()
+		_, _ = LexString("123", fn).Next()
 	}, "Lexer.Discard: No discards allowed after EOF is emitted")
 }

--- a/lexer/marker_test.go
+++ b/lexer/marker_test.go
@@ -23,7 +23,7 @@ func TestMarkerUnused(t *testing.T) {
 	}
 	nexter := LexString("123ABC", fn)
 	expectNexterNext(t, nexter, T_STRING, "123ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMarkerCanReset
@@ -39,7 +39,7 @@ func TestMarkerCanReset(t *testing.T) {
 	}
 	nexter := LexString("123ABC", fn)
 	expectNexterNext(t, nexter, T_STRING, "123ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMarkerImmediateReset
@@ -57,7 +57,7 @@ func TestMarkerImmediateReset(t *testing.T) {
 	}
 	nexter := LexString("123ABC", fn)
 	expectNexterNext(t, nexter, T_STRING, "123ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMarkerReset
@@ -76,7 +76,7 @@ func TestMarkerReset(t *testing.T) {
 	}
 	nexter := LexString("123ABC", fn)
 	expectNexterNext(t, nexter, T_STRING, "123ABC")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMarkerResetInvalid
@@ -96,6 +96,6 @@ func TestMarkerResetInvalid(t *testing.T) {
 		return nil
 	}
 	assertPanic(t, func() {
-		LexString("123ABC", fn).Next()
+		_, _ = LexString("123ABC", fn).Next()
 	}, "Invalid marker")
 }

--- a/lexer/token/README.md
+++ b/lexer/token/README.md
@@ -53,7 +53,7 @@ type Nexter interface {
 	// Even when an error is present, the returned token may still be valid and should be checked.
 	// Once io.EOF is returned, any further calls will continue to return io.EOF.
 	//
-	Next (Token, error)
+	Next(Token, error)
 }
 ```
 

--- a/lexer/token/README.md
+++ b/lexer/token/README.md
@@ -43,22 +43,17 @@ type Type int
 ### token.Nexter
 
 ```go
-// Nexter provides methods to retrieve tokens emitted from the lexer.
-// Implements a basic iterator pattern with HasNext() and Next() methods.
+// Nexter provides a means of retrieving tokens (and errors) emitted from the lexer.
 //
 type Nexter interface {
 
-	// HasNext confirms if there are tokens available.
-	// If it returns true, you can safely call Next() to retrieve the next token.
-	// If it returns false, EOF has been reached and calling Next() will generate a panic.
+	// Next tries to fetch the next available token, returning an error if something goes wrong.
+	// Will return io.EOF to indicate end-of-file.
+	// An error other than io.EOF may be recoverable and does not necessarily indicate end-of-file.
+	// Even when an error is present, the returned token may still be valid and should be checked.
+	// Once io.EOF is returned, any further calls will continue to return io.EOF.
 	//
-	HasNext() bool
-
-	// Next Retrieves the next token from the lexer.
-	// See HasNext() to determine if any tokens are available.
-	// Panics if HasNext() returns false.
-	//
-	Next() Token
+	Next (Token, error)
 }
 ```
 

--- a/lexer/token/README.md
+++ b/lexer/token/README.md
@@ -53,7 +53,7 @@ type Nexter interface {
 	// Even when an error is present, the returned token may still be valid and should be checked.
 	// Once io.EOF is returned, any further calls will continue to return io.EOF.
 	//
-	Next(Token, error)
+	Next() (Token, error)
 }
 ```
 

--- a/lexer/token/token.go
+++ b/lexer/token/token.go
@@ -22,20 +22,15 @@ type Token interface {
 //
 type Type int
 
-// Nexter provides methods to retrieve tokens emitted from the lexer.
-// Implements a basic iterator pattern with HasNext() and Next() methods.
+// Nexter provides a means of retrieving tokens (and errors) emitted from the lexer.
 //
 type Nexter interface {
 
-	// HasNext confirms if there are tokens available.
-	// If it returns true, you can safely call Next() to retrieve the next token.
-	// If it returns false, EOF has been reached and calling Next() will generate a panic.
+	// Next tries to fetch the next available token, returning an error if something goes wrong.
+	// Will return io.EOF to indicate end-of-file.
+	// An error other than io.EOF may be recoverable and does not necessarily indicate end-of-file.
+	// Even when an error is present, the returned token may still be valid and should be checked.
+	// Once io.EOF is returned, any further calls will continue to return io.EOF.
 	//
-	HasNext() bool
-
-	// Next Retrieves the next token from the lexer.
-	// See HasNext() to determine if any tokens are available.
-	// Panics if HasNext() returns false.
-	//
-	Next() Token
+	Next(Token, error)
 }

--- a/lexer/token/token.go
+++ b/lexer/token/token.go
@@ -32,5 +32,5 @@ type Nexter interface {
 	// Even when an error is present, the returned token may still be valid and should be checked.
 	// Once io.EOF is returned, any further calls will continue to return io.EOF.
 	//
-	Next(Token, error)
+	Next() (Token, error)
 }

--- a/lexer/tokennexter.go
+++ b/lexer/tokennexter.go
@@ -32,7 +32,7 @@ func (t *tokenNexter) Next() (token.Token, error) {
 	return tok, nil
 }
 
-// Initiates calls to LexerFn functions and is the primary entry point for retrieving tokens from the lexer.
+// hasNext Initiates calls to LexerFn functions and is the primary entry point for retrieving tokens from the lexer.
 //
 func (t *tokenNexter) hasNext() bool {
 	// If token previously fetched, return now

--- a/lexer/tokennexter.go
+++ b/lexer/tokennexter.go
@@ -1,6 +1,11 @@
 package lexer
 
-import "github.com/tekwizely/go-parsing/lexer/token"
+import (
+	"errors"
+	"io"
+
+	"github.com/tekwizely/go-parsing/lexer/token"
+)
 
 // tokenNexter is the internal structure that backs the lexer's token.Nexter.
 //
@@ -11,22 +16,25 @@ type tokenNexter struct {
 }
 
 // Next implements token.Nexter.Next().
+// We build on the previous HasNext/Next impl to keep changes minimal.
 //
-func (t *tokenNexter) Next() token.Token {
-	// We double check for saved next to maybe avoid the call
-	//
-	if t.next == nil && t.HasNext() == false {
-		panic("Nexter.Next: No token available")
+func (t *tokenNexter) Next() (token.Token, error) {
+	if !t.hasNext() {
+		return nil, io.EOF
 	}
 	tok := t.next
 	t.next = nil
-	return tok
+	// Error?
+	//
+	if tok.Type() == T_LEX_ERR {
+		return nil, errors.New(tok.Value())
+	}
+	return tok, nil
 }
 
-// HasNext implements token.Nexter.HasNext().
 // Initiates calls to LexerFn functions and is the primary entry point for retrieving tokens from the lexer.
 //
-func (t *tokenNexter) HasNext() bool {
+func (t *tokenNexter) hasNext() bool {
 	// If token previously fetched, return now
 	//
 	if t.next != nil {

--- a/lexer/tokennexter_test.go
+++ b/lexer/tokennexter_test.go
@@ -10,11 +10,15 @@ import (
 // expectNexterEOF confirms Next() == (nil, io.EOF)
 //
 func expectNexterEOF(t *testing.T, nexter token.Nexter) {
-	token, err := nexter.Next()
-	if token != nil {
-		t.Errorf("Nexter.Next() expecting (nil, EOF), received ({%d, '%s'}, '%s')", token.Type(), token.Value(), err.Error())
-	} else if err == nil {
-		t.Errorf("Nexter.Next() expecting (nil, EOF), received (nil, nil)")
+	tok, err := nexter.Next()
+	if err == nil {
+		if tok == nil {
+			t.Errorf("Nexter.Next() expecting (nil, EOF), received (nil, nil)")
+		} else {
+			t.Errorf("Nexter.Next() expecting (nil, EOF), received ({%d, '%s'}, nil)", tok.Type(), tok.Value())
+		}
+	} else if tok != nil {
+		t.Errorf("Nexter.Next() expecting (nil, EOF), received ({%d, '%s'}, '%s')'", tok.Type(), tok.Value(), err.Error())
 	} else if err != io.EOF {
 		t.Errorf("Nexter.Next() expecting (nil, EOF), received (nil, '%s')", err.Error())
 	}
@@ -23,24 +27,32 @@ func expectNexterEOF(t *testing.T, nexter token.Nexter) {
 // expectNexterNext confirms Next() == (Token{type, value}, nil)
 //
 func expectNexterNext(t *testing.T, nexter token.Nexter, typ token.Type, value string) {
-	token, err := nexter.Next()
-	if err != nil {
-		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received ({%d, '%s'}, '%s')'", typ, value, token.Type(), token.Value(), err.Error())
-	} else if token == nil {
-		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received (nil, nil)'", typ, value)
-	} else if token.Type() != typ || token.Value() != value {
-		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received ({%d, '%s'}, nil)'", typ, value, token.Type(), token.Value())
+	tok, err := nexter.Next()
+	if tok == nil {
+		if err == nil {
+			t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received (nil, nil)'", typ, value)
+		} else {
+			t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received (nil, '%s')'", typ, value, err.Error())
+		}
+	} else if err != nil {
+		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received ({%d, '%s'}, '%s')'", typ, value, tok.Type(), tok.Value(), err.Error())
+	} else if tok.Type() != typ || tok.Value() != value {
+		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received ({%d, '%s'}, nil)'", typ, value, tok.Type(), tok.Value())
 	}
 }
 
 // expectNexterError confirms Next() == (nil, "$errMsg")
 //
 func expectNexterError(t *testing.T, nexter token.Nexter, errMsg string) {
-	token, err := nexter.Next()
-	if token != nil {
-		t.Errorf("Nexter.Next() expecting (nil, '%s'), received ({%d, '%s'}, '%s')", errMsg, token.Type(), token.Value(), err.Error())
-	} else if err == nil {
-		t.Errorf("Nexter.Next() expecting (nil, '%s'), received (nil, nil)", errMsg)
+	tok, err := nexter.Next()
+	if err == nil {
+		if tok == nil {
+			t.Errorf("Nexter.Next() expecting (nil, '%s'), received (nil, nil)", errMsg)
+		} else {
+			t.Errorf("Nexter.Next() expecting (nil, '%s'), received ({%d, '%s'}, nil)", errMsg, tok.Type(), tok.Value())
+		}
+	} else if tok != nil {
+		t.Errorf("Nexter.Next() expecting (nil, '%s'), received ({%d, '%s'}, '%s')", errMsg, tok.Type(), tok.Value(), err.Error())
 	} else if err.Error() != errMsg {
 		t.Errorf("Nexter.Next() expecting (nil, '%s'), received (nil, '%s')", errMsg, err.Error())
 	}

--- a/lexer/tokennexter_test.go
+++ b/lexer/tokennexter_test.go
@@ -1,28 +1,48 @@
 package lexer
 
 import (
+	"io"
 	"testing"
 
 	"github.com/tekwizely/go-parsing/lexer/token"
 )
 
-// expectNexterHasNext
+// expectNexterEOF confirms Next() == (nil, io.EOF)
 //
-func expectNexterHasNext(t *testing.T, nexter token.Nexter, match bool) {
-	if nexter.HasNext() != match {
-		t.Errorf("Nexter.HasNext() expecting '%t'", match)
+func expectNexterEOF(t *testing.T, nexter token.Nexter) {
+	token, err := nexter.Next()
+	if token != nil {
+		t.Errorf("Nexter.Next() expecting (nil, EOF), received ({%d, '%s'}, '%s')", token.Type(), token.Value(), err.Error())
+	} else if err == nil {
+		t.Errorf("Nexter.Next() expecting (nil, EOF), received (nil, nil)")
+	} else if err != io.EOF {
+		t.Errorf("Nexter.Next() expecting (nil, EOF), received (nil, '%s')", err.Error())
 	}
 }
 
-// expectNexterNext
+// expectNexterNext confirms Next() == (Token{type, value}, nil)
 //
 func expectNexterNext(t *testing.T, nexter token.Nexter, typ token.Type, value string) {
-	tok := nexter.Next()
-	if tok.Type() != typ {
-		t.Errorf("Nexter.Next() expecting Token.Type '%d', received '%d'", typ, tok.Type())
+	token, err := nexter.Next()
+	if err != nil {
+		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received ({%d, '%s'}, '%s')'", typ, value, token.Type(), token.Value(), err.Error())
+	} else if token == nil {
+		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received (nil, nil)'", typ, value)
+	} else if token.Type() != typ || token.Value() != value {
+		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received ({%d, '%s'}, nil)'", typ, value, token.Type(), token.Value())
 	}
-	if tok.Value() != value {
-		t.Errorf("Nexter.Next() expecting Token.String '%s', received '%s'", value, tok.Value())
+}
+
+// expectNexterError confirms Next() == (nil, "$errMsg")
+//
+func expectNexterError(t *testing.T, nexter token.Nexter, errMsg string) {
+	token, err := nexter.Next()
+	if token != nil {
+		t.Errorf("Nexter.Next() expecting (nil, '%s'), received ({%d, '%s'}, '%s')", errMsg, token.Type(), token.Value(), err.Error())
+	} else if err == nil {
+		t.Errorf("Nexter.Next() expecting (nil, '%s'), received (nil, nil)", errMsg)
+	} else if err.Error() != errMsg {
+		t.Errorf("Nexter.Next() expecting (nil, '%s'), received (nil, '%s')", errMsg, err.Error())
 	}
 }
 
@@ -34,9 +54,8 @@ func TestTokensHasNext1(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, true)
 	expectNexterNext(t, nexter, T_START, "")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestTokensHasNext2
@@ -47,25 +66,23 @@ func TestTokensHasNext2(t *testing.T) {
 		return nil
 	}
 	nexter := LexString(".", fn)
-	expectNexterHasNext(t, nexter, true)
-	expectNexterHasNext(t, nexter, true) // Call again, should hit cached 'next' value
 	expectNexterNext(t, nexter, T_START, "")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestTokensEOF
 //
 func TestTokensEOF(t *testing.T) {
 	nexter := LexString(".", nil)
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestTokensNextAfterEOF
 //
 func TestTokensNextAfterEOF(t *testing.T) {
 	nexter := LexString(".", nil)
-	expectNexterHasNext(t, nexter, false)
-	assertPanic(t, func() {
-		nexter.Next()
-	}, "Nexter.Next: No token available")
+	expectNexterEOF(t, nexter)
+	// Call again, should continue to return EOF
+	//
+	expectNexterEOF(t, nexter)
 }

--- a/parser/README.md
+++ b/parser/README.md
@@ -200,21 +200,15 @@ All previously emitted ASTs will still be available for pickup, but the parser w
 
 #### Retrieving Emitted ASTs ( `parser.ASTNexter` )
 
-When called, the Parse function will return an `ASTNexter` which provides methods to retrieve ASTs emitted from the parser.
-
-`ASTNexter` implements a basic iterator pattern:
+When called, the Parse function will return an `ASTNexter` which provides a means of retrieving ASTs emitted from the parser:
 
 ```go
 type ASTNexter interface {
 
-	// HasNext confirms if there are ASTs available.
-	// If it returns true, you can safely call Next() to retrieve the next AST.
+	// Next tries to fetch the next available AST, returning an error if something goes wrong.
+	// Will return io.EOF to indicate end-of-file.
 	//
-	HasNext() bool
-
-	// Next Retrieves the next AST from the parser.
-	//
-	Next() interface{}
+	Next() (interface{}, error)
 }
 ```
 
@@ -319,8 +313,7 @@ func main() {
 
 			// Loop over parser emits
 			//
-			for values.HasNext() {
-				value := values.Next()
+			for value, parseErr := values.Next(); parseErr == nil; value, parseErr = values.Next() {
 				fmt.Printf("%v\n", value)
 			}
 		}

--- a/parser/doc.go
+++ b/parser/doc.go
@@ -126,20 +126,15 @@ you can use this pattern:
 
 Retrieving Emitted ASTs
 
-When called, the `Parse` function will return an `ASTNexter` which provides methods to retrieve ASTs emitted from the
-parser.
-
-`ASTNexter` implements a basic iterator pattern:
+When called, the `Parse` function will return an `ASTNexter` which provides a means of retrieving ASTs emitted from the
+parser:
 
 	type ASTNexter interface {
 
-		// HasNext confirms if there are ASTs available.
+		// Next tries to fetch the next available AST, returning an error if something goes wrong.
+		// Will return io.EOF to indicate end-of-file.
 		//
-		HasNext() bool
-
-		// Next Retrieves the next AST from the parser.
-		//
-		Next() interface{}
+		Next() (interface{}, error)
 	}
 
 

--- a/parser/examples/calc/calc.go
+++ b/parser/examples/calc/calc.go
@@ -92,8 +92,7 @@ func main() {
 
 			// Loop over parser emits
 			//
-			for values.HasNext() {
-				value := values.Next()
+			for value, parseErr := values.Next(); parseErr == nil; value, parseErr = values.Next() {
 				fmt.Printf("%v\n", value)
 			}
 		}

--- a/parser/go.mod
+++ b/parser/go.mod
@@ -13,5 +13,6 @@ require (
 
 // For Local testing against changes that aren't upstream
 //
-//replace github.com/tekwizely/go-parsing/lexer => ../lexer
-//replace github.com/tekwizely/go-parsing/lexer/token => ../lexer/token
+replace github.com/tekwizely/go-parsing/lexer => ../lexer
+
+replace github.com/tekwizely/go-parsing/lexer/token => ../lexer/token

--- a/parser/marker_test.go
+++ b/parser/marker_test.go
@@ -25,7 +25,7 @@ func TestMarkerUnused(t *testing.T) {
 	tokens := mockLexer(T_START)
 	nexter := Parse(tokens, fn)
 	expectNexterNext(t, nexter, "T_START")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMarkerCanReset
@@ -42,7 +42,7 @@ func TestMarkerCanReset(t *testing.T) {
 	tokens := mockLexer(T_START)
 	nexter := Parse(tokens, fn)
 	expectNexterNext(t, nexter, "T_START")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMarkerImmediateReset
@@ -63,7 +63,7 @@ func TestMarkerImmediateReset(t *testing.T) {
 	tokens := mockLexer(T_START)
 	nexter := Parse(tokens, fn)
 	expectNexterNext(t, nexter, "T_START")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMarkerReset
@@ -84,7 +84,7 @@ func TestMarkerReset(t *testing.T) {
 	tokens := mockLexer(T_START)
 	nexter := Parse(tokens, fn)
 	expectNexterNext(t, nexter, "T_START")
-	expectNexterHasNext(t, nexter, false)
+	expectNexterEOF(t, nexter)
 }
 
 // TestMarkerResetInvalid
@@ -107,6 +107,6 @@ func TestMarkerResetInvalid(t *testing.T) {
 	}
 	tokens := mockLexer(T_START)
 	assertPanic(t, func() {
-		Parse(tokens, fn).Next()
+		_, _ = Parse(tokens, fn).Next()
 	}, "Invalid marker")
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"container/list"
+	"io"
 
 	"github.com/tekwizely/go-parsing/lexer/token"
 )
@@ -212,18 +213,34 @@ func (p *Parser) growPeek(n int) bool {
 		if p.eof {
 			return false
 		}
-		// If any tokens remaining?
+		// Fetch next token from input
 		//
-		if p.tokens.HasNext() {
-			// Fetch next token from input
-			//
-			token := p.tokens.Next()
+		token, err := p.tokens.Next()
+		// Process any returned token, regardless of er
+		//
+		if token != nil {
 			p.cache.PushBack(token)
 			peekLen++
-		} else {
-			// EOF
+		}
+		// If there was an error, process it now
+		//
+		if err != nil {
+			switch err {
+			// EOF Error
 			//
-			p.eof = true
+			case io.EOF:
+				p.eof = true
+
+			// NON-EOF Error
+			//
+			default:
+				// For lack of a better plan, treat as EOF for now
+				// TODO Think about how to handle non-EOF errors.
+				// TODO Log error.
+				// TODO Expose upstream?
+				//
+				p.eof = true
+			}
 		}
 	}
 	return true


### PR DESCRIPTION
Closes #2 

Went with the `value, error` solution (vs `value, ok`).

For the lexer, this re-routes `lexer.EmitError()` messages as `error` values.

For the parser, it was a toss-up as, currently there is no mechanism within the framework to emit errors from the parser.  So `io.EOF` is the only error that can currently be emitted.


