### PR TITLE
fix: Line 1 showing as 0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
     #       always_run: true        # Run even if no matching files staged
     # ==========================================================================
 -   repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v0.6.1
+    rev: v1.0.0-beta.4
     hooks:
       -   id: go-build-mod
           alias: build
@@ -79,7 +79,8 @@ repos:
           alias: test
       -   id: go-vet-mod
           alias: vet
-      -   id: go-fmt-fix
+      -   id: go-fmt-repo
+          args: ['-w']
           alias: fmt
 #     -   id: go-imports-fix # replaces go-fmt-fix
 #     -   id: go-returns-fix # replaces go-imports-fix & go-fmt-fix
@@ -94,5 +95,5 @@ repos:
       # - Supports repo config file for configuration
       # - https://github.com/golangci/golangci-lint
       #
-      -   id: golangci-lint-dir-fix
-          alias: ci
+#      -   id: golangci-lint
+#          alias: ci

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -399,7 +399,7 @@ func (l *Lexer) clear(returnText bool) (string, int, int) {
 	// Default values. Will update if matchLen > 0
 	//
 	line, column := l.line, l.column
-	first := false
+	first := true
 	for l.matchLen > 0 {
 		e := l.cache.Front()
 		r := e.Value.(rune)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -414,7 +414,7 @@ func (l *Lexer) clear(returnText bool) (string, int, int) {
 		if l.column == 0 {
 			l.column = 1
 		}
-		// If first pass, save line/column
+		// If first pass, re-fetch (possibly adjusted) values
 		//
 		if first {
 			line, column = l.line, l.column

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -133,7 +133,7 @@ func TestLexerFnSkippedWhenNoCanPeek(t *testing.T) {
 	expectNexterEOF(t, nexter)
 }
 
-// TestEmittoken.Ttype
+// TestEmitEmptyType
 //
 func TestEmitEmptyType(t *testing.T) {
 	fn := func(l *Lexer) Fn {

--- a/lexer/tokennexter_test.go
+++ b/lexer/tokennexter_test.go
@@ -38,7 +38,7 @@ func expectNexterNext(t *testing.T, nexter token.Nexter, typ token.Type, value s
 		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received (nil, '%s')'", typ, value, err.Error())
 	case tok != nil && err != nil:
 		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received ({%d, '%s'}, '%s')'", typ, value, tok.Type(), tok.Value(), err.Error())
-	case tok != nil && err == nil && (tok.Type() != typ || tok.Value() != value):
+	case tok != nil && err == nil && (tok.Type() != typ || tok.Value() != value || tok.Line() != line || tok.Column() != column):
 		assertToken(t, tok.(*_token), typ, value, line, column, false)
 	}
 }

--- a/lexer/tokennexter_test.go
+++ b/lexer/tokennexter_test.go
@@ -38,7 +38,7 @@ func expectNexterNext(t *testing.T, nexter token.Nexter, typ token.Type, value s
 		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received (nil, '%s')'", typ, value, err.Error())
 	case tok != nil && err != nil:
 		t.Errorf("Nexter.Next() expecting ({%d, '%s'}, nil), received ({%d, '%s'}, '%s')'", typ, value, tok.Type(), tok.Value(), err.Error())
-	case tok != nil && err == nil && (tok.Type() != typ || tok.Value() != value || tok.Line() != line || tok.Column() != column):
+	case tok != nil && err == nil:
 		assertToken(t, tok.(*_token), typ, value, line, column, false)
 	}
 }


### PR DESCRIPTION
Fixes bug discovered in https://github.com/TekWizely/run/pull/38 where line 1 shows up as 0.

* Fixes bad init var for line 1 check
* Fixes expectNexterNext to actually check expected line / column 
* Updates pre-commit-golang to v1.0.0-beta.4

---

cc: @rburchell